### PR TITLE
chore: pin zarr to <3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     'donfig',
     'pytest',
     'universal_pathlib>=0.2.0',
-    "zarr>=3.0.3",
+    "zarr>=3.0.3,<3.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
3.1 will include breaking changes for zarrs-python