### PR TITLE
fix: stop using `ChunkCoords`

### DIFF
--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from zarr.core.array_spec import ArraySpec
     from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
     from zarr.core.chunk_grids import ChunkGrid
-    from zarr.core.common import ChunkCoords
     from zarr.core.indexing import SelectorTuple
     from zarr.dtype import ZDType
 
@@ -151,7 +150,7 @@ class ZarrsCodecPipeline(CodecPipeline):
         yield from self.codecs
 
     def validate(
-        self, *, shape: ChunkCoords, dtype: ZDType, chunk_grid: ChunkGrid
+        self, *, shape: tuple[int, ...], dtype: ZDType, chunk_grid: ChunkGrid
     ) -> None:
         raise NotImplementedError("validate")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 from zarr import config
-from zarr.core.common import ChunkCoords
 from zarr.storage import FsspecStore, LocalStore, MemoryStore, ZipStore
 
 from zarrs.utils import (  # noqa: F401
@@ -20,12 +19,12 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from zarr.abc.store import Store
-    from zarr.core.common import ChunkCoords, MemoryOrder
+    from zarr.core.common import MemoryOrder
 
 
 @dataclass
 class ArrayRequest:
-    shape: ChunkCoords
+    shape: tuple[int, ...]
     dtype: str
     order: MemoryOrder
 


### PR DESCRIPTION
`ChunkCoords` was broken in `zarr-python` 3.1.2, but fortunately we only it for type checking/tests.

I've fixed this upstream with https://github.com/zarr-developers/zarr-python/pull/3425, but we might as well stop using it.