### PR TITLE
Use entrypoint to register Zarrs codec pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ To use the project, simply install our package (which depends on `zarr-python>=3
 
 ```python
 import zarr
-import zarrs
 zarr.config.set({"codec_pipeline.path": "zarrs.ZarrsCodecPipeline"})
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
     {include-group = "doc"},
 ]
 
+[project.entry-points."zarr.codec_pipeline"]
+"zarrs.codec_pipeline" = "zarrs:ZarrsCodecPipeline"
+
 [tool.maturin]
 python-source = "python"
 module-name = "zarrs._internal"

--- a/python/zarrs/__init__.py
+++ b/python/zarrs/__init__.py
@@ -1,5 +1,3 @@
-from zarr.registry import register_pipeline
-
 from ._internal import __version__
 from .pipeline import ZarrsCodecPipeline as _ZarrsCodecPipeline
 from .utils import CollapsedDimensionError, DiscontiguousArrayError
@@ -9,8 +7,6 @@ from .utils import CollapsedDimensionError, DiscontiguousArrayError
 class ZarrsCodecPipeline(_ZarrsCodecPipeline):
     pass
 
-
-register_pipeline(ZarrsCodecPipeline)
 
 __all__ = [
     "ZarrsCodecPipeline",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,6 @@ import pytest
 from zarr import config
 from zarr.storage import FsspecStore, LocalStore, MemoryStore, ZipStore
 
-from zarrs.utils import (  # noqa: F401
-    CollapsedDimensionError,
-    DiscontiguousArrayError,
-)
-
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Any, Literal

--- a/tests/data/check-registry.py
+++ b/tests/data/check-registry.py
@@ -13,7 +13,11 @@ with zarr.config.set({"codec_pipeline.path": "zarrs.ZarrsCodecPipeline"}):
     else:
         is_registered = True
 
-print(json.dumps(dict(
-    imported_modules=imported_modules,
-    is_registered=is_registered,
-)))
+print(
+    json.dumps(
+        dict(
+            imported_modules=imported_modules,
+            is_registered=is_registered,
+        )
+    )
+)

--- a/tests/data/check-registry.py
+++ b/tests/data/check-registry.py
@@ -1,0 +1,19 @@
+import json
+import sys
+
+import zarr
+
+# imported_modules must be determined first
+imported_modules = list(sys.modules)
+with zarr.config.set({"codec_pipeline.path": "zarrs.ZarrsCodecPipeline"}):
+    try:
+        zarr.array([])
+    except zarr.core.config.BadConfigError:
+        is_registered = False
+    else:
+        is_registered = True
+
+print(json.dumps(dict(
+    imported_modules=imported_modules,
+    is_registered=is_registered,
+)))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,7 +15,7 @@ import pytest
 import zarr
 from zarr.storage import LocalStore
 
-import zarrs  # noqa: F401
+import zarrs
 
 axis_size_ = 10
 chunk_size_ = axis_size_ // 2

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,12 @@
+import sys
+import json
+from subprocess import run
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+def test_registerable_when_not_imported():
+    proc = run([sys.executable, "-I", HERE / "data/check-registry.py"], capture_output=True, check=True)
+    results = json.loads(proc.stdout)
+    assert "zarrs" not in results["imported_modules"]
+    assert results["is_registered"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,12 +1,17 @@
-import sys
 import json
-from subprocess import run
+import sys
 from pathlib import Path
+from subprocess import run
 
 HERE = Path(__file__).parent
 
+
 def test_registerable_when_not_imported():
-    proc = run([sys.executable, "-I", HERE / "data/check-registry.py"], capture_output=True, check=True)
+    proc = run(
+        [sys.executable, "-I", HERE / "data/check-registry.py"],
+        capture_output=True,
+        check=True,
+    )
     results = json.loads(proc.stdout)
     assert "zarrs" not in results["imported_modules"]
     assert results["is_registered"]


### PR DESCRIPTION
This avoids the need to import `zarrs`, which allows `zarrs-python` to be enabled purely through configuration.