### PR TITLE
chore: migrate to zarrs 0.24 (not merge ready until `zarrs 0.24` and `zarrs-storage` 0.4.6 are published)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.27.1", features = ["abi3-py311"] }
-zarrs = { version = "0.23.6", features = ["async", "zlib", "pcodec", "bz2"] }
+# ON THE 0.24 RELEASE: replace with `zarrs = { version = "0.24", features = [...] }` AND
+# delete the [patch.crates-io] block below, in the SAME commit -- see the note there for why
+# doing only one of the two builds silently against the wrong `zarrs_storage`. src/ already
+# compiles against the 0.24 API.
+zarrs = { git = "https://github.com/zarrs/zarrs", rev = "c17fe374b1fa7df8373b6c6f6eb3f1d33c3a3bd7", features = ["async", "zlib", "pcodec", "bz2"] }
 rayon_iter_concurrent_limit = "0.2.0"
 rayon = "1.10.0"
 # fix for https://stackoverflow.com/questions/76593417/package-openssl-was-not-found-in-the-pkg-config-search-path
@@ -29,3 +33,16 @@ zarrs_object_store = "0.5.0" # object_store 0.12
 
 [profile.release]
 lto = true
+
+# ON THE 0.24 RELEASE: delete this, in the same commit that drops the git rev above.
+#
+# `zarrs_opendal` and `zarrs_object_store` do not depend on `zarrs` at all -- only on
+# `zarrs_storage`, from crates.io. While `zarrs` comes from git that is a SECOND copy of
+# `zarrs_storage`, so there are two `AsyncReadableStorageTraits` and the bounds on the async
+# stores cannot be satisfied. Patching the one crate to the same rev collapses the graph.
+#
+# Drop the git rev above WITHOUT deleting this and the build is silently wrong: released
+# `zarrs 0.24` compiled against an unpublished `zarrs_storage`. Nothing warns, because the
+# git copy carries the same version number as the published one with different contents.
+[patch.crates-io]
+zarrs_storage = { git = "https://github.com/zarrs/zarrs", rev = "c17fe374b1fa7df8373b6c6f6eb3f1d33c3a3bd7" }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -25,7 +25,7 @@ impl ChunkConcurrentLimitAndCodecOptions for Vec<ChunkItem> {
 
         let codec_concurrency = codec_pipeline_impl
             .codec_chain
-            .recommended_concurrency(&item.shape, &codec_pipeline_impl.data_type)
+            .recommended_concurrency(&item.shape)
             .map_codec_err()?;
 
         let min_concurrent_chunks =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,11 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon_iter_concurrent_limit::iter_concurrent_limit;
 use unsafe_cell_slice::UnsafeCellSlice;
 use utils::is_whole_chunk;
+use zarrs::array::codec::api::BytesPartialDecoderTraits;
 use zarrs::array::{
     ArrayBytes, ArrayBytesDecodeIntoTarget, ArrayBytesFixedDisjointView, ArrayMetadata,
-    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecChain, CodecOptions, DataType,
-    FillValue, StoragePartialDecoder, copy_fill_value_into, update_array_bytes,
+    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecChain, CodecChainBound, CodecOptions,
+    DataType, FillValue, copy_fill_value_into, update_array_bytes,
 };
 use zarrs::config::global_config;
 use zarrs::convert::array_metadata_v2_to_v3;
@@ -50,7 +51,7 @@ pub(crate) struct CodecPipelineImpl {
     /// The writable handle -- `None` when zarr-python opened the store read-only. Same object
     /// as `readable_store`; the read-only case simply never keeps a writable view of it.
     pub(crate) writable_store: Option<ReadableWritableListableStorage>,
-    pub(crate) codec_chain: Arc<CodecChain>,
+    pub(crate) codec_chain: Arc<CodecChainBound>,
     pub(crate) codec_options: CodecOptions,
     pub(crate) chunk_concurrent_minimum: usize,
     pub(crate) chunk_concurrent_maximum: usize,
@@ -63,7 +64,7 @@ impl CodecPipelineImpl {
     fn retrieve_chunk_bytes<'a>(
         &self,
         item: &ChunkItem,
-        codec_chain: &CodecChain,
+        codec_chain: &CodecChainBound,
         codec_options: &CodecOptions,
     ) -> PyResult<ArrayBytes<'a>> {
         let value_encoded = self
@@ -73,13 +74,7 @@ impl CodecPipelineImpl {
         let value_decoded = if let Some(value_encoded) = value_encoded {
             let value_encoded: Vec<u8> = value_encoded.into(); // zero-copy in this case
             codec_chain
-                .decode(
-                    value_encoded.into(),
-                    &item.shape,
-                    &self.data_type,
-                    &self.fill_value,
-                    codec_options,
-                )
+                .decode(value_encoded.into(), &item.shape, codec_options)
                 .map_codec_err()?
         } else {
             ArrayBytes::new_fill_value(&self.data_type, item.num_elements, &self.fill_value)
@@ -98,7 +93,7 @@ impl CodecPipelineImpl {
     fn store_chunk_bytes(
         &self,
         item: &ChunkItem,
-        codec_chain: &CodecChain,
+        codec_chain: &CodecChainBound,
         value_decoded: ArrayBytes,
         codec_options: &CodecOptions,
     ) -> PyResult<()> {
@@ -112,13 +107,7 @@ impl CodecPipelineImpl {
             store.erase(&item.key).map_py_err::<PyRuntimeError>()
         } else {
             let value_encoded = codec_chain
-                .encode(
-                    value_decoded,
-                    &item.shape,
-                    &self.data_type,
-                    &self.fill_value,
-                    codec_options,
-                )
+                .encode(value_decoded, &item.shape, codec_options)
                 .map(Cow::into_owned)
                 .map_codec_err()?;
 
@@ -132,7 +121,7 @@ impl CodecPipelineImpl {
     fn store_chunk_subset_bytes(
         &self,
         item: &ChunkItem,
-        codec_chain: &CodecChain,
+        codec_chain: &CodecChainBound,
         chunk_subset_bytes: ArrayBytes,
         codec_options: &CodecOptions,
     ) -> PyResult<()> {
@@ -257,8 +246,10 @@ impl CodecPipelineImpl {
             }
             ArrayMetadata::V3(v3) => Cow::Borrowed(v3),
         };
+        // Parsed before binding, so an array with bad codecs and a bad fill value still
+        // reports the codecs.
         let codec_chain =
-            Arc::new(CodecChain::from_metadata(&metadata_v3.codecs).map_py_err::<PyTypeError>()?);
+            CodecChain::from_metadata(&metadata_v3.codecs).map_py_err::<PyTypeError>()?;
         let codec_options = CodecOptions::default().with_validate_checksums(validate_checksums);
 
         let chunk_concurrent_minimum =
@@ -286,6 +277,10 @@ impl CodecPipelineImpl {
                     metadata.data_type, metadata.fill_value
                 ),
             })
+            .map_py_err::<PyTypeError>()?;
+
+        let codec_chain = codec_chain
+            .with_context(data_type.clone(), fill_value.clone())
             .map_py_err::<PyTypeError>()?;
 
         Ok(Self {
@@ -328,18 +323,15 @@ impl CodecPipelineImpl {
         if !partial_chunk_items.is_empty() {
             let key_decoder_pairs =
                 iter_concurrent_limit!(chunk_concurrent_limit, partial_chunk_items, map, |item| {
-                    let storage_handle = Arc::new(StorageHandle::new(self.readable_store.clone()));
-                    let input_handle = StoragePartialDecoder::new(storage_handle, item.key.clone());
+                    // The (storage, key) tuple IS the store-backed `BytesPartialDecoderTraits`.
+                    let input_handle: Arc<dyn BytesPartialDecoderTraits> = Arc::new((
+                        StorageHandle::new(self.readable_store.clone()),
+                        item.key.clone(),
+                    ));
                     let partial_decoder = self
                         .codec_chain
                         .clone()
-                        .partial_decoder(
-                            Arc::new(input_handle),
-                            &item.shape,
-                            &self.data_type,
-                            &self.fill_value,
-                            &codec_options,
-                        )
+                        .partial_decoder(input_handle, &item.shape, &codec_options)
                         .map_codec_err()?;
                     Ok((item.key.clone(), partial_decoder))
                 })
@@ -382,8 +374,6 @@ impl CodecPipelineImpl {
                         self.codec_chain.decode_into(
                             Cow::Owned(chunk_encoded),
                             &item.shape,
-                            &self.data_type,
-                            &self.fill_value,
                             target,
                             &codec_options,
                         )


### PR DESCRIPTION
A dependency bump and the API migration it forces, and nothing else. This PR is blocked until `zarrs 0.24` and `zarrs-storage 0.4.6` are published